### PR TITLE
Avoid using a global variable for ggbAplet

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -3,6 +3,10 @@ Release notes for GeoGebra Module for Moodle (http://moodle.org/plugins/pluginve
 More information on each of the fixes can be found in the project
 development home at https://github.com/projectestac/moodle-mod_geogebra
 
+Changes in 3.6.3 (2021/10/10)
+---------------------------------------------------------------------------------------
+- Fixed an error in geogebra_view.js that prevented submitting or storing attempts 
+
 Changes in 3.6.2 (2021/06/09)
 ---------------------------------------------------------------------------------------
 - Fixed loading of activities due to a change in the remote javascript from geogebra.org

--- a/locallib.php
+++ b/locallib.php
@@ -397,11 +397,9 @@ function geogebra_get_js_from_geogebra($context, $geogebra) {
         return;
     }
 
-    echo '<script type="text/javascript">
-    if (typeof ggbApplet == \'undefined\') {
-        ggbApplet = document.ggbApplet;
-    }
-    ' .$content . '</script>';
+    // Modified: 20/10/2021
+    // Global variable `ggbApplet` not yet used
+    echo '<script type="text/javascript">' .$content . '</script>';
 }
 
 /**

--- a/version.php
+++ b/version.php
@@ -29,9 +29,9 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2021060900;      // The current module version (Date: YYYYMMDDXX)
+$plugin->version   = 2021102100;      // The current module version (Date: YYYYMMDDXX)
 $plugin->requires  = 2015111600;      // Requires this Moodle version (2.7)
 $plugin->cron      = 0;               // Period for cron to check this module (secs)
 $plugin->component = 'mod_geogebra';  // To check on upgrade, that module sits in correct place
-$plugin->release   = 'v3.6.2';        // Human-readable version name
+$plugin->release   = 'v3.6.3';        // Human-readable version name
 $plugin->maturity  = MATURITY_STABLE; // How stable the plugin is


### PR DESCRIPTION
The name `ggbApplet` is already used as the `id` attribute of the DOM element containing the GeoGebra applet.
This `ID` attribute pollutes the root namespace with `window.ggbApplet` (or just `ggbApplet`) pointing to a
DOM element, not to the expected GeoGebra javascript object initialized in `locallib.php`.

The proposed solution is to use `document.ggbApplet` when needed, instead of referencing a global variable.

Resolves #63