### PR TITLE
Add a random value when building the name of a temp directory, to avoid possible concurrency issues

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -3,6 +3,15 @@ Release notes for GeoGebra Module for Moodle (http://moodle.org/plugins/pluginve
 More information on each of the fixes can be found in the project
 development home at https://github.com/projectestac/moodle-mod_geogebra
 
+Changes in 3.6.7 (2022/06/09)
+---------------------------------------------------------------------------------------
+- Add a random value when building the name of a temp directory, to avoid possible concurrency issues
+- Added indexes to improve performance when there are a lot of attempts
+- Updated validation of external URL
+- Set https in tube.geogebra.org. Fixed deprecated function
+- MBS-5843: Fix unittest
+- Removed empty string as a default value for CHAR NOT NULL column (urlggb)
+
 Changes in 3.6.6 (2022/01/16)
 ---------------------------------------------------------------------------------------
 - Set params `seed` and `urlggb` as advanced.

--- a/locallib.php
+++ b/locallib.php
@@ -360,7 +360,7 @@ function geogebra_get_js_from_geogebra($context, $geogebra) {
     if (geogebra_is_valid_external_url($geogebra->url)) {
         require_once("$CFG->libdir/filestorage/zip_packer.php");
         // Prepare tmp dir (create if not exists, download ggb file...)
-        $dirname = 'mod_geogebra_'.time();
+        $dirname = 'mod_geogebra_'.time().rand(0, 9999);
         $tmpdir = make_temp_directory($dirname);
         if (!$tmpdir) {
             debugging("Cannot create temp directory $dirname");

--- a/version.php
+++ b/version.php
@@ -29,9 +29,9 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2022060700;      // The current module version (Date: YYYYMMDDXX)
+$plugin->version   = 2022060900;      // The current module version (Date: YYYYMMDDXX)
 $plugin->requires  = 2015111600;      // Requires this Moodle version (2.7)
 $plugin->cron      = 0;               // Period for cron to check this module (secs)
 $plugin->component = 'mod_geogebra';  // To check on upgrade, that module sits in correct place
-$plugin->release   = 'v3.6.7';        // Human-readable version name
+$plugin->release   = 'v3.6.8';        // Human-readable version name
 $plugin->maturity  = MATURITY_STABLE; // How stable the plugin is


### PR DESCRIPTION
Name of temp directory in [geogebra_get_js_from_geogebra](https://github.com/projectestac/moodle-mod_geogebra/blob/master/locallib.php#L363) uses `time()` to generate random directory names. This can cause concurrency issues with multiple users are accessing at the same time.

Added a random value to the temporal directory name to minimize this risk.
