### PR TITLE
MBS-7391: Replace the deprecated print_error by moodle exception

### DIFF
--- a/attempt.php
+++ b/attempt.php
@@ -18,7 +18,7 @@ if ($id) {
     $course = $DB->get_record('course', ['id' => $geogebra->course], '*', MUST_EXIST);
     $cm = get_coursemodule_from_instance('geogebra', $geogebra->id, $course->id, false, MUST_EXIST);
 } else {
-    print_error('You must specify a course_module ID or an instance ID');
+    throw new \moodle_exception('You must specify a course_module ID or an instance ID');
 }
 
 $context = context_module::instance($cm->id);
@@ -26,7 +26,7 @@ $context = context_module::instance($cm->id);
 // Activity was sent before the applet was fully loaded.
 parse_str($vars, $parsedVars);
 if (empty($vars)) {
-    print_error('The applet has not sent correct data');
+    throw new \moodle_exception('The applet has not sent correct data');
 }
 
 require_login($course, true, $cm);
@@ -59,10 +59,10 @@ parse_str($vars, $parsedVars);
 
 if ($attempt) { // Exists an unfishined attempt.
     if (!(geogebra_update_attempt($attempt->id, $vars, GEOGEBRA_UPDATE_STUDENT, $attempt->gradecomment, $f))) {
-        print_error(get_string('errorattempt', 'geogebra'));
+        throw new \moodle_exception(get_string('errorattempt', 'geogebra'));
     }
 } else if (!(geogebra_add_attempt($geogebra->id, $USER->id, $vars, $f))) {
-    print_error(get_string('errorattempt', 'geogebra'));
+    throw new \moodle_exception(get_string('errorattempt', 'geogebra'));
 }
 
 // TODO: Show saved information message

--- a/index.php
+++ b/index.php
@@ -34,7 +34,7 @@ require_once(dirname(__FILE__).'/lib.php');
 $id = required_param('id', PARAM_INT);   // course
 
 if (! $course = $DB->get_record('course', array('id' => $id))) {
-    print_error('Course ID is incorrect');
+    throw new \moodle_exception('Course ID is incorrect');
 }
 
 require_course_login($course);

--- a/report.php
+++ b/report.php
@@ -39,7 +39,7 @@ if ($id) {
     $course     = $DB->get_record('course', array('id' => $cm->course), '*', MUST_EXIST);
     $geogebra  = $DB->get_record('geogebra', array('id' => $cm->instance), '*', MUST_EXIST);
 } else {
-    print_error('You must specify a course_module ID or an instance ID');
+    throw new \moodle_exception('You must specify a course_module ID or an instance ID');
 }
 
 require_login($course, true, $cm);

--- a/view.php
+++ b/view.php
@@ -44,7 +44,7 @@ if ($id) {
     $course = $DB->get_record('course', ['id' => $geogebra->course], '*', MUST_EXIST);
     $cm = get_coursemodule_from_instance('geogebra', $geogebra->id, $course->id, false, MUST_EXIST);
 } else {
-    print_error('You must specify a course_module ID or an instance ID');
+    throw new \moodle_exception('You must specify a course_module ID or an instance ID');
 }
 
 require_login($course, true, $cm);
@@ -84,7 +84,7 @@ if ($attemptid) {
     if ($cangrade || $attempt->userid == $USER->id) {
         echo geogebra_view_applet($geogebra, $cm, $context, $attempt, true);
     } else {
-        print_error(get_string('accessdenied', 'admin'));
+        throw new \moodle_exception(get_string('accessdenied', 'admin'));
     }
 } else {
     echo geogebra_view_applet($geogebra, $cm, $context, null, false);


### PR DESCRIPTION
Print error is deprecated from moodle 4.1. It should be replaced by threw new moodle exception