### PR TITLE
Fix encoding/decoding of links to view and index

### DIFF
--- a/backup/moodle2/backup_geogebra_activity_task.class.php
+++ b/backup/moodle2/backup_geogebra_activity_task.class.php
@@ -59,11 +59,11 @@ class backup_geogebra_activity_task extends backup_activity_task {
 
         // Link to the list of geogebras
         $search="/(".$base."\/mod\/geogebra\/index.php\?id\=)([0-9]+)/";
-        $content= preg_replace($search, '$@geogebraINDEX*$2@$', $content);
+        $content= preg_replace($search, '$@GEOGEBRAINDEX*$2@$', $content);
 
         // Link to geogebra view by moduleid
         $search="/(".$base."\/mod\/geogebra\/view.php\?id\=)([0-9]+)/";
-        $content= preg_replace($search, '$@geogebraVIEWBYID*$2@$', $content);
+        $content= preg_replace($search, '$@GEOGEBRAVIEWBYID*$2@$', $content);
 
         return $content;
 


### PR DESCRIPTION
The encoding/decoding of course internal links to the index and view pages are implemented, but they do not work because of a capitalisation mismatch. It is a very simple fix.

To reproduce without this patch

- create a course with a geogebra activity
- add a link to the view page of that activity in a label or a page
- duplicate the course
- confirm that in the duplicated course the link is broken: it has been encoded but not decoded and appears as `https://YOURSITE/course/$@geogebraVIEWBYID*1048@$`

Confirm that with this patch the steps above produce a working link to the activity in the copied course.