### PR TITLE
Add Moodle Playground preview blueprint and PR action

### DIFF
--- a/.github/workflows/pr-playground-preview.yml
+++ b/.github/workflows/pr-playground-preview.yml
@@ -1,0 +1,30 @@
+---
+name: PR Playground Preview
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited]
+
+concurrency:
+  group: playground-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  playground-preview:
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - uses: ateeducacion/action-moodle-playground-pr-preview@main
+        with:
+          blueprint-file: blueprint.json
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          moodle-version: '5.2'

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ can preview and try it without any local setup. Every pull request also
 automatically generates a playground preview link appended to the PR
 description, so reviewers can test changes in a live Moodle instance.
 
-<a href="https://moodle-playground.com/?blueprint-url=https://raw.githubusercontent.com/erseco/moodle-mod_geogebra/refs/heads/main/blueprint.json" target="_blank" rel="noopener"><img src="https://raw.githubusercontent.com/ateeducacion/action-moodle-playground-pr-preview/refs/heads/main/assets/playground-preview-button.svg" alt="Preview in Moodle Playground" width="200"></a>
+<a href="https://moodle-playground.com/?blueprint-url=https://raw.githubusercontent.com/projectestac/moodle-mod_geogebra/refs/heads/master/blueprint.json" target="_blank" rel="noopener"><img src="https://raw.githubusercontent.com/ateeducacion/action-moodle-playground-pr-preview/refs/heads/main/assets/playground-preview-button.svg" alt="Preview in Moodle Playground" width="200"></a>
 
 The PR preview links are produced by the
 [ateeducacion/action-moodle-playground-pr-preview](https://github.com/ateeducacion/action-moodle-playground-pr-preview)

--- a/README.md
+++ b/README.md
@@ -1,0 +1,30 @@
+# GeoGebra activity module for Moodle (`mod_geogebra`)
+
+[GeoGebra](https://www.geogebra.org/) is a free, multi-platform dynamic
+mathematics software for all levels of education that brings together
+geometry, algebra, tables, graphing, statistics and calculus in one
+easy-to-use package.
+
+This Moodle activity module lets teachers embed GeoGebra activities in a
+course, store each attempt's score / date / duration / construction, and
+let students resume saved work.
+
+## Try in Moodle Playground
+
+Click the badge below to open the `main` branch instantly in Moodle
+Playground with the plugin pre-installed. The playground boots straight
+into a demo course with a sample GeoGebra activity already created, so you
+can preview and try it without any local setup. Every pull request also
+automatically generates a playground preview link appended to the PR
+description, so reviewers can test changes in a live Moodle instance.
+
+<a href="https://moodle-playground.com/?blueprint-url=https://raw.githubusercontent.com/erseco/moodle-mod_geogebra/refs/heads/main/blueprint.json" target="_blank" rel="noopener"><img src="https://raw.githubusercontent.com/ateeducacion/action-moodle-playground-pr-preview/refs/heads/main/assets/playground-preview-button.svg" alt="Preview in Moodle Playground" width="200"></a>
+
+The PR preview links are produced by the
+[ateeducacion/action-moodle-playground-pr-preview](https://github.com/ateeducacion/action-moodle-playground-pr-preview)
+GitHub Action, configured via `blueprint.json` at the repository root.
+
+## Installation & credits
+
+See [`README.txt`](README.txt) for installation instructions, upstream
+history and the full list of contributors.

--- a/blueprint.json
+++ b/blueprint.json
@@ -30,7 +30,7 @@
       "step": "installMoodlePlugin",
       "pluginType": "mod",
       "pluginName": "geogebra",
-      "url": "https://github.com/erseco/moodle-mod_geogebra/archive/refs/heads/main.zip"
+      "url": "https://github.com/projectestac/moodle-mod_geogebra/archive/refs/heads/master.zip"
     },
     {
       "step": "createCategory",

--- a/blueprint.json
+++ b/blueprint.json
@@ -1,0 +1,75 @@
+{
+  "$schema": "https://raw.githubusercontent.com/ateeducacion/moodle-playground/refs/heads/main/assets/blueprints/blueprint-schema.json",
+  "preferredVersions": {
+    "php": "8.3",
+    "moodle": "5.2"
+  },
+  "landingPage": "/course/view.php?id=2",
+  "constants": {
+    "ADMIN_USER": "admin",
+    "ADMIN_PASS": "test",
+    "ADMIN_EMAIL": "admin@example.com"
+  },
+  "steps": [
+    {
+      "step": "installMoodle",
+      "options": {
+        "adminUser": "{{ADMIN_USER}}",
+        "adminPass": "{{ADMIN_PASS}}",
+        "adminEmail": "{{ADMIN_EMAIL}}",
+        "siteName": "GeoGebra Activity Demo",
+        "locale": "en",
+        "timezone": "Europe/Madrid"
+      }
+    },
+    {
+      "step": "login",
+      "username": "{{ADMIN_USER}}"
+    },
+    {
+      "step": "installMoodlePlugin",
+      "pluginType": "mod",
+      "pluginName": "geogebra",
+      "url": "https://github.com/erseco/moodle-mod_geogebra/archive/refs/heads/main.zip"
+    },
+    {
+      "step": "createCategory",
+      "name": "Test Courses"
+    },
+    {
+      "step": "createCourse",
+      "fullname": "GeoGebra Demo Course",
+      "shortname": "GEOGEBRA01",
+      "category": "Test Courses",
+      "summary": "Demo course for the mod_geogebra activity module. A sample GeoGebra activity is preloaded so you can open it and try the embedded applet right away."
+    },
+    {
+      "step": "createUser",
+      "username": "student",
+      "password": "test",
+      "email": "student@example.com",
+      "firstname": "Demo",
+      "lastname": "Student"
+    },
+    {
+      "step": "enrolUser",
+      "username": "{{ADMIN_USER}}",
+      "course": "GEOGEBRA01",
+      "role": "editingteacher"
+    },
+    {
+      "step": "enrolUser",
+      "username": "student",
+      "course": "GEOGEBRA01",
+      "role": "student"
+    },
+    {
+      "step": "runPhpCode",
+      "code": "if (!defined('CLI_SCRIPT')) { define('CLI_SCRIPT', true); }\nrequire('/www/moodle/config.php');\nrequire_once($CFG->dirroot . '/course/lib.php');\nrequire_once($CFG->dirroot . '/mod/geogebra/lib.php');\nrequire_once($CFG->dirroot . '/mod/geogebra/locallib.php');\ntry {\n    $course = $DB->get_record('course', ['shortname' => 'GEOGEBRA01'], '*', MUST_EXIST);\n    $admin = get_admin();\n    \\core\\session\\manager::set_user($admin);\n    $now = time();\n    $geogebra = (object)[\n        'course'        => $course->id,\n        'name'          => 'Sample GeoGebra activity',\n        'intro'         => '<p>Open this activity to try an embedded GeoGebra applet loaded from a public GeoGebra material.</p>',\n        'introformat'   => FORMAT_HTML,\n        'filetype'      => GEOGEBRA_FILE_TYPE_EXTERNAL,\n        'geogebraurl'   => 'https://www.geogebra.org/material/iframe/id/RHYH3UV8',\n        'url'           => 'https://www.geogebra.org/material/iframe/id/RHYH3UV8',\n        'urlggb'        => '',\n        'language'      => '',\n        'seed'          => 1,\n        'maxattempts'   => 0,\n        'grade'         => 100,\n        'grademethod'   => GEOGEBRA_HIGHEST_GRADE,\n        'attributes'    => '',\n        'showsubmit'    => 1,\n        'timeavailable' => 0,\n        'timedue'       => 0,\n        'timecreated'   => $now,\n        'timemodified'  => $now,\n    ];\n    $module = $DB->get_record('modules', ['name' => 'geogebra'], '*', MUST_EXIST);\n    $cm = (object)[\n        'course'       => $course->id,\n        'module'       => $module->id,\n        'instance'     => 0,\n        'section'      => 1,\n        'idnumber'     => '',\n        'added'        => $now,\n        'score'        => 0,\n        'indent'       => 0,\n        'visible'      => 1,\n        'visibleold'   => 1,\n        'groupmode'    => 0,\n        'groupingid'   => 0,\n        'completion'   => 0,\n        'showdescription' => 0,\n    ];\n    $cmid = add_course_module($cm);\n    $geogebra->coursemodule = $cmid;\n    $instanceid = geogebra_add_instance($geogebra, null);\n    $DB->set_field('course_modules', 'instance', $instanceid, ['id' => $cmid]);\n    course_add_cm_to_section($course->id, $cmid, 1);\n    rebuild_course_cache($course->id, true);\n    echo \"Created mod_geogebra instance id={$instanceid} cmid={$cmid} in course {$course->shortname}\\n\";\n} catch (\\Throwable $e) {\n    echo 'ERROR: ' . $e->getMessage() . \"\\n\";\n}"
+    },
+    {
+      "step": "setLandingPage",
+      "path": "/course/view.php?id=2"
+    }
+  ]
+}


### PR DESCRIPTION
## About this PR — Moodle Playground

[Moodle Playground](https://moodle-playground.com) (source: [ateeducacion/moodle-playground](https://github.com/ateeducacion/moodle-playground)) is a project that runs a full Moodle site **entirely inside the browser** (PHP + SQLite compiled to WebAssembly), with no server, no Docker and no local install. Given a `blueprint.json` it provisions a fresh Moodle instance, installs plugins, creates users / courses / sample content, and opens on a chosen landing page.

This PR wires that up for this plugin so contributors and reviewers can **try and test the plugin in a real Moodle instance with one click** — useful both for users who just want to evaluate it and for reviewers who want to validate a change without standing up a local Moodle.

---

> ℹ️ **Live PR-preview demo:** see the same change applied on my fork at https://github.com/erseco/moodle-mod_geogebra/pull/1 — once the workflow finishes, that PR's description gets a "Preview in Moodle Playground" button appended automatically. That is exactly what every future PR opened against this repo will look like once this is merged.

## Summary
- Adds `blueprint.json` describing a Moodle 5.2 demo site with `mod_geogebra` installed, a demo course (`GEOGEBRA01`), admin + student users, and a pre-created sample GeoGebra activity using an external GeoGebra material URL so the embedded applet works out of the box.
- Adds `.github/workflows/pr-playground-preview.yml` which uses `ateeducacion/action-moodle-playground-pr-preview` to publish a live Moodle Playground preview link on every PR.
- Adds `README.md` with a "Try in Moodle Playground" badge linking to the blueprint, leaving the existing `README.txt` (upstream install notes / credits) intact.

## Test plan
- [ ] Workflow `PR Playground Preview` runs on this PR and appends a preview link to the PR description.
- [ ] Opening the preview link boots a Moodle site with `mod_geogebra` installed.
- [ ] Landing page is the `GEOGEBRA01` demo course and the sample GeoGebra activity is visible.
- [ ] Clicking the sample activity loads the embedded GeoGebra applet.
